### PR TITLE
Added script to setup the pi so that it connects to the web server on boot

### DIFF
--- a/pi_setup2.sh
+++ b/pi_setup2.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+echo "Starting setup for telepresence robot at " $(date "+%Y.%m.%d-%H.%M.%S")
+echo "Making backup of rc.local..."
+
+if [ -e /etc/rc.local.backup ]
+then
+    echo "Backup of rc.local already exists... Did you already run this script?" 
+    exit 1
+else
+    cp /etc/rc.local /etc/rc.local.backup
+fi
+
+echo "Replacing rc.local with new one..."
+
+if [ -e ./rc.local ]
+then
+    cp ./rc.local /etc/rc.local
+else
+    echo "New rc.local not found..."
+    exit 1
+fi
+
+echo "Done! Restart the raspberry pi to enable the robot"

--- a/rc.local
+++ b/rc.local
@@ -1,0 +1,16 @@
+#!/bin/sh -e
+#
+# rc.local
+#
+# This script is executed at the end of each multiuser runlevel.
+# Make sure that the script will "exit 0" on success or any other
+# value on error.
+#
+# In order to enable or disable this script just change the execution
+# bits.
+#
+# By default this script does nothing.
+
+SERVER=127.0.0.1 PORT=80 node index.js &
+
+exit 0


### PR DESCRIPTION
Here's a little script for the raspberry pi so that it connects to the web server when it boots. The line in the rc.local file will need to be updated with the server address and port (I don't remember what they are).

This should probably be added to the existing setup script, but I don't know how the bish stuff works, so I didn't touch it.
